### PR TITLE
add context to public functions

### DIFF
--- a/iq/application_test.go
+++ b/iq/application_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -109,7 +110,7 @@ func TestGetAllApplications(t *testing.T) {
 	iq, mock := applicationTestIQ(t)
 	defer mock.Close()
 
-	applications, err := GetAllApplications(iq)
+	applications, err := GetAllApplicationsContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -133,7 +134,7 @@ func TestGetApplicationByPublicID(t *testing.T) {
 
 	dummyAppsIdx := 2
 
-	got, err := GetApplicationByPublicID(iq, dummyApps[dummyAppsIdx].PublicID)
+	got, err := GetApplicationByPublicIDContext(context.Background(), iq, dummyApps[dummyAppsIdx].PublicID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -197,7 +198,7 @@ func TestCreateApplication(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateApplication(tt.args.iq, tt.args.name, tt.args.id, tt.args.organizationID)
+			got, err := CreateApplicationContext(context.Background(), tt.args.iq, tt.args.name, tt.args.id, tt.args.organizationID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateApplication() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -216,16 +217,16 @@ func TestDeleteApplication(t *testing.T) {
 	deleteMeApp := Application{PublicID: "deleteMeApp", Name: "deleteMeApp", OrganizationID: "deleteMeAppOrgId"}
 
 	var err error
-	deleteMeApp.ID, err = CreateApplication(iq, deleteMeApp.Name, deleteMeApp.PublicID, deleteMeApp.OrganizationID)
+	deleteMeApp.ID, err = CreateApplicationContext(context.Background(), iq, deleteMeApp.Name, deleteMeApp.PublicID, deleteMeApp.OrganizationID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := DeleteApplication(iq, deleteMeApp.PublicID); err != nil {
+	if err := DeleteApplicationContext(context.Background(), iq, deleteMeApp.PublicID); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := GetApplicationByPublicID(iq, deleteMeApp.PublicID); err == nil {
+	if _, err := GetApplicationByPublicIDContext(context.Background(), iq, deleteMeApp.PublicID); err == nil {
 		t.Fatal("App was not deleted")
 	}
 }
@@ -254,7 +255,7 @@ func TestGetApplicationsByOrganization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetApplicationsByOrganization(tt.args.iq, tt.args.organizationName)
+			got, err := GetApplicationsByOrganizationContext(context.Background(), tt.args.iq, tt.args.organizationName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetApplicationsByOrganization() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -272,7 +273,7 @@ func ExampleGetAllApplications() {
 		panic(err)
 	}
 
-	applications, err := GetAllApplications(iq)
+	applications, err := GetAllApplicationsContext(context.Background(), iq)
 	if err != nil {
 		panic(err)
 	}
@@ -286,7 +287,7 @@ func ExampleCreateApplication() {
 		panic(err)
 	}
 
-	appID, err := CreateApplication(iq, "name", "id", "organization")
+	appID, err := CreateApplicationContext(context.Background(), iq, "name", "id", "organization")
 	if err != nil {
 		panic(err)
 	}

--- a/iq/componentDetails_test.go
+++ b/iq/componentDetails_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -88,13 +89,13 @@ func TestGetComponent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetComponent(tt.args.iq, tt.args.component)
+			got, err := GetComponentContext(context.Background(), tt.args.iq, tt.args.component)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetComponent() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetComponentContext() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetComponent() = %v, want %v", got, tt.want)
+				t.Errorf("GetComponentContext() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -106,7 +107,7 @@ func TestGetComponents(t *testing.T) {
 
 	expected := dummyComponentDetails[0]
 
-	details, err := GetComponents(iq, []Component{expected.Component})
+	details, err := GetComponentsContext(context.Background(), iq, []Component{expected.Component})
 	if err != nil {
 		t.Error(err)
 	}
@@ -145,13 +146,13 @@ func TestGetComponentsByApplication(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetComponentsByApplication(tt.args.iq, tt.args.appPublicID)
+			got, err := GetComponentsByApplicationContext(context.Background(), tt.args.iq, tt.args.appPublicID)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetComponentsByApplication() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetComponentsByApplicationContext() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetComponentsByApplication() = %v, want %v", got, tt.want)
+				t.Errorf("GetComponentsByApplicationContext() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -180,13 +181,13 @@ func TestGetAllComponents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetAllComponents(tt.args.iq)
+			got, err := GetAllComponentsContext(context.Background(), tt.args.iq)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetAllComponents() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetAllComponentsContext() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAllComponents() = %v, want %v", got, tt.want)
+				t.Errorf("GetAllComponentsContext() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/iq/componentLabels.go
+++ b/iq/componentLabels.go
@@ -2,6 +2,7 @@ package nexusiq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,15 +27,14 @@ type IqComponentLabel struct {
 	Color          string `json:"color"`
 }
 
-// ComponentLabelApply adds an existing label to a component for a given application
-func ComponentLabelApply(iq IQ, comp Component, appID, label string) error {
-	app, err := GetApplicationByPublicID(iq, appID)
+func ComponentLabelApplyContext(ctx context.Context, iq IQ, comp Component, appID, label string) error {
+	app, err := GetApplicationByPublicIDContext(ctx, iq, appID)
 	if err != nil {
 		return fmt.Errorf("could not retrieve application with ID %s: %v", appID, err)
 	}
 
 	endpoint := fmt.Sprintf(restLabelComponent, comp.Hash, url.PathEscape(label), app.ID)
-	_, resp, err := iq.Post(endpoint, nil)
+	_, resp, err := iq.Post(ctx, endpoint, nil)
 	if err != nil {
 		if resp == nil || resp.StatusCode != http.StatusNoContent {
 			return fmt.Errorf("could not apply label: %v", err)
@@ -44,15 +44,19 @@ func ComponentLabelApply(iq IQ, comp Component, appID, label string) error {
 	return nil
 }
 
-// ComponentLabelUnapply removes an existing association between a label and a component
-func ComponentLabelUnapply(iq IQ, comp Component, appID, label string) error {
-	app, err := GetApplicationByPublicID(iq, appID)
+// ComponentLabelApply adds an existing label to a component for a given application
+func ComponentLabelApply(iq IQ, comp Component, appID, label string) error {
+	return ComponentLabelApplyContext(context.Background(), iq, comp, appID, label)
+}
+
+func ComponentLabelUnapplyContext(ctx context.Context, iq IQ, comp Component, appID, label string) error {
+	app, err := GetApplicationByPublicIDContext(ctx, iq, appID)
 	if err != nil {
 		return fmt.Errorf("could not retrieve application with ID %s: %v", appID, err)
 	}
 
 	endpoint := fmt.Sprintf(restLabelComponent, comp.Hash, url.PathEscape(label), app.ID)
-	resp, err := iq.Del(endpoint)
+	resp, err := iq.Del(ctx, endpoint)
 	if err != nil {
 		if resp == nil || resp.StatusCode != http.StatusNoContent {
 			return fmt.Errorf("could not unapply label: %v", err)
@@ -62,8 +66,13 @@ func ComponentLabelUnapply(iq IQ, comp Component, appID, label string) error {
 	return nil
 }
 
-func getComponentLabels(iq IQ, endpoint string) ([]IqComponentLabel, error) {
-	body, _, err := iq.Get(endpoint)
+// ComponentLabelUnapply removes an existing association between a label and a component
+func ComponentLabelUnapply(iq IQ, comp Component, appID, label string) error {
+	return ComponentLabelUnapplyContext(context.Background(), iq, comp, appID, label)
+}
+
+func getComponentLabels(ctx context.Context, iq IQ, endpoint string) ([]IqComponentLabel, error) {
+	body, _, err := iq.Get(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -77,26 +86,34 @@ func getComponentLabels(iq IQ, endpoint string) ([]IqComponentLabel, error) {
 	return labels, nil
 }
 
+func GetComponentLabelsByOrganizationContext(ctx context.Context, iq IQ, organization string) ([]IqComponentLabel, error) {
+	endpoint := fmt.Sprintf(restLabelComponentByOrg, organization)
+	return getComponentLabels(ctx, iq, endpoint)
+}
+
 // GetComponentLabelsByOrganization retrieves an array of an organization's component label
 func GetComponentLabelsByOrganization(iq IQ, organization string) ([]IqComponentLabel, error) {
-	endpoint := fmt.Sprintf(restLabelComponentByOrg, organization)
-	return getComponentLabels(iq, endpoint)
+	return GetComponentLabelsByOrganizationContext(context.Background(), iq, organization)
+}
+
+func GetComponentLabelsByAppIDContext(ctx context.Context, iq IQ, appID string) ([]IqComponentLabel, error) {
+	endpoint := fmt.Sprintf(restLabelComponentByApp, appID)
+	return getComponentLabels(ctx, iq, endpoint)
 }
 
 // GetComponentLabelsByAppID retrieves an array of an organization's component label
 func GetComponentLabelsByAppID(iq IQ, appID string) ([]IqComponentLabel, error) {
-	endpoint := fmt.Sprintf(restLabelComponentByApp, appID)
-	return getComponentLabels(iq, endpoint)
+	return GetComponentLabelsByAppIDContext(context.Background(), iq, appID)
 }
 
-func createLabel(iq IQ, endpoint, label, description, color string) (IqComponentLabel, error) {
+func createLabel(ctx context.Context, iq IQ, endpoint, label, description, color string) (IqComponentLabel, error) {
 	var labelResponse IqComponentLabel
 	request, err := json.Marshal(IqComponentLabel{Label: label, Description: description, Color: color})
 	if err != nil {
 		return labelResponse, fmt.Errorf("could not marshal label: %v", err)
 	}
 
-	body, resp, err := iq.Post(endpoint, bytes.NewBuffer(request))
+	body, resp, err := iq.Post(ctx, endpoint, bytes.NewBuffer(request))
 	if resp.StatusCode != http.StatusOK {
 		return labelResponse, fmt.Errorf("did not succeeed in creating label: %v", err)
 	}
@@ -109,22 +126,45 @@ func createLabel(iq IQ, endpoint, label, description, color string) (IqComponent
 	return labelResponse, nil
 }
 
+func CreateComponentLabelForOrganizationContext(ctx context.Context, iq IQ, organization, label, description, color string) (IqComponentLabel, error) {
+	endpoint := fmt.Sprintf(restLabelComponentByOrg, organization)
+	return createLabel(ctx, iq, endpoint, label, description, color)
+}
+
 // CreateComponentLabelForOrganization creates a label for an organization
 func CreateComponentLabelForOrganization(iq IQ, organization, label, description, color string) (IqComponentLabel, error) {
-	endpoint := fmt.Sprintf(restLabelComponentByOrg, organization)
-	return createLabel(iq, endpoint, label, description, color)
+	return CreateComponentLabelForOrganizationContext(context.Background(), iq, organization, label, description, color)
+}
+
+func CreateComponentLabelForApplicationContext(ctx context.Context, iq IQ, appID, label, description, color string) (IqComponentLabel, error) {
+	endpoint := fmt.Sprintf(restLabelComponentByApp, appID)
+	return createLabel(ctx, iq, endpoint, label, description, color)
 }
 
 // CreateComponentLabelForApplication creates a label for an application
 func CreateComponentLabelForApplication(iq IQ, appID, label, description, color string) (IqComponentLabel, error) {
-	endpoint := fmt.Sprintf(restLabelComponentByApp, appID)
-	return createLabel(iq, endpoint, label, description, color)
+	return CreateComponentLabelForApplicationContext(context.Background(), iq, appID, label, description, color)
+}
+
+func DeleteComponentLabelForOrganizationContext(ctx context.Context, iq IQ, organization, label string) error {
+	endpoint := fmt.Sprintf(restLabelComponentByOrgDel, organization, label)
+	resp, err := iq.Del(ctx, endpoint)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("did not succeeed in deleting label: %v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
 }
 
 // DeleteComponentLabelForOrganization deletes a label from an organization
 func DeleteComponentLabelForOrganization(iq IQ, organization, label string) error {
-	endpoint := fmt.Sprintf(restLabelComponentByOrgDel, organization, label)
-	resp, err := iq.Del(endpoint)
+	return DeleteComponentLabelForOrganizationContext(context.Background(), iq, organization, label)
+}
+
+func DeleteComponentLabelForApplicationContext(ctx context.Context, iq IQ, appID, label string) error {
+	endpoint := fmt.Sprintf(restLabelComponentByAppDel, appID, label)
+	resp, err := iq.Del(ctx, endpoint)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("did not succeeed in deleting label: %v", err)
 	}
@@ -135,12 +175,5 @@ func DeleteComponentLabelForOrganization(iq IQ, organization, label string) erro
 
 // DeleteComponentLabelForApplication deletes a label from an application
 func DeleteComponentLabelForApplication(iq IQ, appID, label string) error {
-	endpoint := fmt.Sprintf(restLabelComponentByAppDel, appID, label)
-	resp, err := iq.Del(endpoint)
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("did not succeeed in deleting label: %v", err)
-	}
-	defer resp.Body.Close()
-
-	return nil
+	return DeleteComponentLabelForApplicationContext(context.Background(), iq, appID, label)
 }

--- a/iq/componentLabels_test.go
+++ b/iq/componentLabels_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +56,7 @@ func TestComponentLabelApply(t *testing.T) {
 
 	label, component, appID := dummyLabels[0], dummyComponent, dummyApps[0].PublicID
 
-	if err := ComponentLabelApply(iq, component, appID, label); err != nil {
+	if err := ComponentLabelApplyContext(context.Background(), iq, component, appID, label); err != nil {
 		t.Error(err)
 	}
 }
@@ -66,11 +67,11 @@ func TestComponentLabelUnapply(t *testing.T) {
 
 	label, component, appID := dummyLabels[0], dummyComponent, dummyApps[0].PublicID
 
-	if err := ComponentLabelApply(iq, component, appID, label); err != nil {
+	if err := ComponentLabelApplyContext(context.Background(), iq, component, appID, label); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := ComponentLabelUnapply(iq, component, appID, label); err != nil {
+	if err := ComponentLabelUnapplyContext(context.Background(), iq, component, appID, label); err != nil {
 		t.Error(err)
 	}
 }

--- a/iq/componentVersions.go
+++ b/iq/componentVersions.go
@@ -2,20 +2,20 @@ package nexusiq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 )
 
 const restComponentVersions = "api/v2/components/versions"
 
-// ComponentVersions returns all known versions of a given component
-func ComponentVersions(iq IQ, comp Component) (versions []string, err error) {
+func ComponentVersionsContext(ctx context.Context, iq IQ, comp Component) (versions []string, err error) {
 	str, err := json.Marshal(comp)
 	if err != nil {
 		return nil, fmt.Errorf("could not process component: %v", err)
 	}
 
-	body, _, err := iq.Post(restComponentVersions, bytes.NewBuffer(str))
+	body, _, err := iq.Post(ctx, restComponentVersions, bytes.NewBuffer(str))
 	if err != nil {
 		return nil, fmt.Errorf("could not request component: %v", err)
 	}
@@ -25,4 +25,9 @@ func ComponentVersions(iq IQ, comp Component) (versions []string, err error) {
 	}
 
 	return
+}
+
+// ComponentVersions returns all known versions of a given component
+func ComponentVersions(iq IQ, comp Component) (versions []string, err error) {
+	return ComponentVersionsContext(context.Background(), iq, comp)
 }

--- a/iq/componentVersions_test.go
+++ b/iq/componentVersions_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -62,7 +63,7 @@ func TestComponentVersions(t *testing.T) {
 	iq, mock := componentVersionsTestIQ(t)
 	defer mock.Close()
 
-	versions, err := ComponentVersions(iq, dummyComponent)
+	versions, err := ComponentVersionsContext(context.Background(), iq, dummyComponent)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/componentsRemediation_test.go
+++ b/iq/componentsRemediation_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -103,7 +104,7 @@ func TestRemediationByApp(t *testing.T) {
 
 	id, stage := dummyApps[0].PublicID, "build"
 
-	remediation, err := GetRemediationByApp(iq, dummyComponent, stage, id)
+	remediation, err := GetRemediationByAppContext(context.Background(), iq, dummyComponent, stage, id)
 	if err != nil {
 		t.Error(err)
 	}
@@ -120,7 +121,7 @@ func TestRemediationByOrg(t *testing.T) {
 
 	id, stage := dummyOrgs[0].Name, "build"
 
-	remediation, err := GetRemediationByOrg(iq, dummyComponent, stage, id)
+	remediation, err := GetRemediationByOrgContext(context.Background(), iq, dummyComponent, stage, id)
 	if err != nil {
 		t.Error(err)
 	}
@@ -138,7 +139,7 @@ func TestRemediationByAppReport(t *testing.T) {
 
 	appIdx, reportID := 0, "0"
 
-	got, err := GetRemediationsByAppReport(iq, dummyApps[appIdx].PublicID, reportID)
+	got, err := GetRemediationsByAppReportContext(context.Background(), iq, dummyApps[appIdx].PublicID, reportID)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/dataRetentionPolicies_test.go
+++ b/iq/dataRetentionPolicies_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -98,7 +99,7 @@ func TestGetRetentionPolicies(t *testing.T) {
 	iq, mock := dataRetentionPoliciesTestIQ(t)
 	defer mock.Close()
 
-	policies, err := GetRetentionPolicies(iq, dummyOrgs[0].Name)
+	policies, err := GetRetentionPoliciesContext(context.Background(), iq, dummyOrgs[0].Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -135,12 +136,12 @@ func TestSetRetentionPolicies(t *testing.T) {
 		SuccessMetrics: expected.SuccessMetrics,
 	}
 
-	err := SetRetentionPolicies(iq, dummyOrgs[0].Name, retentionRequest)
+	err := SetRetentionPoliciesContext(context.Background(), iq, dummyOrgs[0].Name, retentionRequest)
 	if err != nil {
 		t.Error(err)
 	}
 
-	got, err := GetRetentionPolicies(iq, dummyOrgs[0].Name)
+	got, err := GetRetentionPoliciesContext(context.Background(), iq, dummyOrgs[0].Name)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/evaluation_test.go
+++ b/iq/evaluation_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -98,7 +99,7 @@ func TestEvaluateComponents(t *testing.T) {
 
 	appID := "dummyAppId"
 
-	report, err := EvaluateComponents(iq, []Component{dummyComponent}, appID)
+	report, err := EvaluateComponentsContext(context.Background(), iq, []Component{dummyComponent}, appID)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/organization_test.go
+++ b/iq/organization_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -68,7 +69,7 @@ func TestGetOranizationByName(t *testing.T) {
 
 	dummyOrgsIdx := 2
 
-	org, err := GetOrganizationByName(iq, dummyOrgs[dummyOrgsIdx].Name)
+	org, err := GetOrganizationByNameContext(context.Background(), iq, dummyOrgs[dummyOrgsIdx].Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,12 +91,12 @@ func TestCreateOrganization(t *testing.T) {
 	createdOrg := Organization{Name: "createdOrg"}
 
 	var err error
-	createdOrg.ID, err = CreateOrganization(iq, createdOrg.Name)
+	createdOrg.ID, err = CreateOrganizationContext(context.Background(), iq, createdOrg.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	org, err := GetOrganizationByName(iq, createdOrg.Name)
+	org, err := GetOrganizationByNameContext(context.Background(), iq, createdOrg.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +112,7 @@ func TestGetAllOrganizations(t *testing.T) {
 	iq, mock := organizationTestIQ(t)
 	defer mock.Close()
 
-	organizations, err := GetAllOrganizations(iq)
+	organizations, err := GetAllOrganizationsContext(context.Background(), iq)
 	if err != nil {
 		panic(err)
 	}
@@ -125,7 +126,7 @@ func ExampleCreateOrganization() {
 		panic(err)
 	}
 
-	orgID, err := CreateOrganization(iq, "DatabaseTeam")
+	orgID, err := CreateOrganizationContext(context.Background(), iq, "DatabaseTeam")
 	if err != nil {
 		panic(err)
 	}

--- a/iq/policies.go
+++ b/iq/policies.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -21,9 +22,8 @@ type policiesList struct {
 	Policies []PolicyInfo `json:"policies"`
 }
 
-// GetPolicies returns a list of all of the policies in IQ
-func GetPolicies(iq IQ) ([]PolicyInfo, error) {
-	body, _, err := iq.Get(restPolicies)
+func GetPoliciesContext(ctx context.Context, iq IQ) ([]PolicyInfo, error) {
+	body, _, err := iq.Get(ctx, restPolicies)
 	if err != nil {
 		return nil, fmt.Errorf("could not get list of policies: %v", err)
 	}
@@ -36,9 +36,13 @@ func GetPolicies(iq IQ) ([]PolicyInfo, error) {
 	return resp.Policies, nil
 }
 
-// GetPolicyInfoByName returns an information object for the named policy
-func GetPolicyInfoByName(iq IQ, policyName string) (PolicyInfo, error) {
-	policies, err := GetPolicies(iq)
+// GetPolicies returns a list of all of the policies in IQ
+func GetPolicies(iq IQ) ([]PolicyInfo, error) {
+	return GetPoliciesContext(context.Background(), iq)
+}
+
+func GetPolicyInfoByNameContext(ctx context.Context, iq IQ, policyName string) (PolicyInfo, error) {
+	policies, err := GetPoliciesContext(ctx, iq)
 	if err != nil {
 		return PolicyInfo{}, fmt.Errorf("did not find policy with name %s: %v", policyName, err)
 	}
@@ -50,4 +54,9 @@ func GetPolicyInfoByName(iq IQ, policyName string) (PolicyInfo, error) {
 	}
 
 	return PolicyInfo{}, fmt.Errorf("did not find policy with name %s", policyName)
+}
+
+// GetPolicyInfoByName returns an information object for the named policy
+func GetPolicyInfoByName(iq IQ, policyName string) (PolicyInfo, error) {
+	return GetPolicyInfoByNameContext(context.Background(), iq, policyName)
 }

--- a/iq/policies_test.go
+++ b/iq/policies_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,7 +51,7 @@ func TestGetPolicies(t *testing.T) {
 	iq, mock := policiesTestIQ(t)
 	defer mock.Close()
 
-	infos, err := GetPolicies(iq)
+	infos, err := GetPoliciesContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -72,7 +73,7 @@ func TestGetPolicyInfoByName(t *testing.T) {
 
 	expected := dummyPolicyInfos[0]
 
-	info, err := GetPolicyInfoByName(iq, expected.Name)
+	info, err := GetPolicyInfoByNameContext(context.Background(), iq, expected.Name)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/policyViolations.go
+++ b/iq/policyViolations.go
@@ -2,6 +2,7 @@ package nexusiq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -18,9 +19,8 @@ type violationResponse struct {
 	ApplicationViolations []ApplicationViolation `json:"applicationViolations"`
 }
 
-// GetAllPolicyViolations returns all policy violations
-func GetAllPolicyViolations(iq IQ) ([]ApplicationViolation, error) {
-	policyInfos, err := GetPolicies(iq)
+func GetAllPolicyViolationsContext(ctx context.Context, iq IQ) ([]ApplicationViolation, error) {
+	policyInfos, err := GetPoliciesContext(ctx, iq)
 	if err != nil {
 		return nil, fmt.Errorf("could not get policies: %v", err)
 	}
@@ -33,7 +33,7 @@ func GetAllPolicyViolations(iq IQ) ([]ApplicationViolation, error) {
 		endpoint.WriteString(i.ID)
 	}
 
-	body, _, err := iq.Get(endpoint.String())
+	body, _, err := iq.Get(ctx, endpoint.String())
 	if err != nil {
 		return nil, fmt.Errorf("could not get policy violations: %v", err)
 	}
@@ -47,9 +47,13 @@ func GetAllPolicyViolations(iq IQ) ([]ApplicationViolation, error) {
 	return resp.ApplicationViolations, nil
 }
 
-// GetPolicyViolationsByName returns the policy violations by policy name
-func GetPolicyViolationsByName(iq IQ, policyNames ...string) ([]ApplicationViolation, error) {
-	policies, err := GetPolicies(iq)
+// GetAllPolicyViolations returns all policy violations
+func GetAllPolicyViolations(iq IQ) ([]ApplicationViolation, error) {
+	return GetAllPolicyViolationsContext(context.Background(), iq)
+}
+
+func GetPolicyViolationsByNameContext(ctx context.Context, iq IQ, policyNames ...string) ([]ApplicationViolation, error) {
+	policies, err := GetPoliciesContext(ctx, iq)
 	if err != nil {
 		return nil, fmt.Errorf("did not find policy: %v", err)
 	}
@@ -67,7 +71,7 @@ func GetPolicyViolationsByName(iq IQ, policyNames ...string) ([]ApplicationViola
 		}
 	}
 
-	body, _, err := iq.Get(endpoint.String())
+	body, _, err := iq.Get(ctx, endpoint.String())
 	if err != nil {
 		return nil, fmt.Errorf("could not get policy violations: %v", err)
 	}
@@ -79,4 +83,9 @@ func GetPolicyViolationsByName(iq IQ, policyNames ...string) ([]ApplicationViola
 	}
 
 	return resp.ApplicationViolations, nil
+}
+
+// GetPolicyViolationsByName returns the policy violations by policy name
+func GetPolicyViolationsByName(iq IQ, policyNames ...string) ([]ApplicationViolation, error) {
+	return GetPolicyViolationsByNameContext(context.Background(), iq, policyNames...)
 }

--- a/iq/policyViolations_test.go
+++ b/iq/policyViolations_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -80,7 +81,7 @@ func TestGetAllPolicyViolations(t *testing.T) {
 	iq, mock := policyViolationsTestIQ(t)
 	defer mock.Close()
 
-	violations, err := GetAllPolicyViolations(iq)
+	violations, err := GetAllPolicyViolationsContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -102,7 +103,7 @@ func TestGetPolicyViolationsByName(t *testing.T) {
 
 	expected := dummyPolicyViolations[0]
 
-	violations, err := GetPolicyViolationsByName(iq, expected.PolicyViolations[0].PolicyName)
+	violations, err := GetPolicyViolationsByNameContext(context.Background(), iq, expected.PolicyViolations[0].PolicyName)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/reportMetrics_test.go
+++ b/iq/reportMetrics_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -197,7 +198,7 @@ func TestMetricsRequestBuilder(t *testing.T) {
 	defer mock.Close()
 
 	for _, test := range tests {
-		got, err := test.input.build(iq)
+		got, err := test.input.build(context.Background(), iq)
 		if err != nil {
 			t.Errorf("Unexpected error building metrics request: %v", err)
 			t.Error("input", test.input)
@@ -230,7 +231,7 @@ func TestGenerateMetrics(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got, err := GenerateMetrics(iq, test.input)
+		got, err := GenerateMetricsContext(context.Background(), iq, test.input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -251,7 +252,7 @@ func ExampleGenerateMetrics() {
 
 	reqLastYear := NewMetricsRequestBuilder().Monthly().StartingOn(time.Now().Add(-(24 * time.Hour) * 365)).WithApplication("WebGoat")
 
-	metrics, err := GenerateMetrics(iq, reqLastYear)
+	metrics, err := GenerateMetricsContext(context.Background(), iq, reqLastYear)
 	if err != nil {
 		panic(err)
 	}

--- a/iq/reports_test.go
+++ b/iq/reports_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -162,7 +163,7 @@ func TestGetAllReportInfos(t *testing.T) {
 	iq, mock := reportsTestIQ(t)
 	defer mock.Close()
 
-	infos, err := GetAllReportInfos(iq)
+	infos, err := GetAllReportInfosContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -184,7 +185,7 @@ func TestGetReportInfosByAppID(t *testing.T) {
 
 	testIdx := 0
 
-	infos, err := GetReportInfosByAppID(iq, dummyApps[testIdx].PublicID)
+	infos, err := GetReportInfosByAppIDContext(context.Background(), iq, dummyApps[testIdx].PublicID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -204,7 +205,7 @@ func Test_getRawReportByAppReportID(t *testing.T) {
 
 	testIdx := 0
 
-	report, err := getRawReportByAppReportID(iq, dummyApps[testIdx].PublicID, fmt.Sprintf("%d", testIdx))
+	report, err := getRawReportByAppReportID(context.Background(), iq, dummyApps[testIdx].PublicID, fmt.Sprintf("%d", testIdx))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +222,7 @@ func TestGetRawReportByAppID(t *testing.T) {
 
 	testIdx := 0
 
-	report, err := GetRawReportByAppID(iq, dummyApps[testIdx].PublicID, dummyReportInfos[testIdx].Stage)
+	report, err := GetRawReportByAppIDContext(context.Background(), iq, dummyApps[testIdx].PublicID, dummyReportInfos[testIdx].Stage)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +239,7 @@ func TestGetPolicyReportByAppID(t *testing.T) {
 
 	testIdx := 0
 
-	report, err := GetPolicyReportByAppID(iq, dummyApps[testIdx].PublicID, dummyReportInfos[testIdx].Stage)
+	report, err := GetPolicyReportByAppIDContext(context.Background(), iq, dummyApps[testIdx].PublicID, dummyReportInfos[testIdx].Stage)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +256,7 @@ func TestGetReportByAppID(t *testing.T) {
 
 	testIdx := 0
 
-	report, err := GetReportByAppID(iq, dummyApps[testIdx].PublicID, dummyReportInfos[testIdx].Stage)
+	report, err := GetReportByAppIDContext(context.Background(), iq, dummyApps[testIdx].PublicID, dummyReportInfos[testIdx].Stage)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +295,7 @@ func TestGetReportInfosByOrganization(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotInfos, err := GetReportInfosByOrganization(tt.args.iq, tt.args.organizationName)
+			gotInfos, err := GetReportInfosByOrganizationContext(context.Background(), tt.args.iq, tt.args.organizationName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetReportInfosByOrganization() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/iq/roleMemberships_test.go
+++ b/iq/roleMemberships_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -397,7 +398,7 @@ func testGetOrganizationAuthorizations(t *testing.T, iq IQ) {
 	t.Helper()
 	dummyIdx := 0
 
-	got, err := OrganizationAuthorizations(iq, dummyOrgs[dummyIdx].Name)
+	got, err := OrganizationAuthorizationsContext(context.Background(), iq, dummyOrgs[dummyIdx].Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -424,7 +425,7 @@ func testGetOrganizationAuthorizationsByRole(t *testing.T, iq IQ) {
 		}
 	}
 
-	got, err := OrganizationAuthorizationsByRole(iq, role.Name)
+	got, err := OrganizationAuthorizationsByRoleContext(context.Background(), iq, role.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -448,7 +449,7 @@ func testGetApplicationAuthorizations(t *testing.T, iq IQ) {
 	t.Helper()
 	dummyIdx := 0
 
-	got, err := ApplicationAuthorizations(iq, dummyApps[dummyIdx].PublicID)
+	got, err := ApplicationAuthorizationsContext(context.Background(), iq, dummyApps[dummyIdx].PublicID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -474,7 +475,7 @@ func testGetApplicationAuthorizationsByRole(t *testing.T, iq IQ) {
 		}
 	}
 
-	got, err := ApplicationAuthorizationsByRole(iq, role.Name)
+	got, err := ApplicationAuthorizationsByRoleContext(context.Background(), iq, role.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -517,22 +518,22 @@ func testSetAuth(t *testing.T, iq IQ, authTarget string, memberType string) {
 	case "organization":
 		switch memberType {
 		case MemberTypeUser:
-			err = SetOrganizationUser(iq, dummyOrgs[dummyIdx].Name, dummyRoles[role].Name, memberName)
+			err = SetOrganizationUserContext(context.Background(), iq, dummyOrgs[dummyIdx].Name, dummyRoles[role].Name, memberName)
 		case MemberTypeGroup:
-			err = SetOrganizationGroup(iq, dummyOrgs[dummyIdx].Name, dummyRoles[role].Name, memberName)
+			err = SetOrganizationGroupContext(context.Background(), iq, dummyOrgs[dummyIdx].Name, dummyRoles[role].Name, memberName)
 		}
 		if err == nil {
-			got, err = OrganizationAuthorizations(iq, dummyOrgs[dummyIdx].Name)
+			got, err = OrganizationAuthorizationsContext(context.Background(), iq, dummyOrgs[dummyIdx].Name)
 		}
 	case "application":
 		switch memberType {
 		case MemberTypeUser:
-			err = SetApplicationUser(iq, dummyApps[dummyIdx].PublicID, dummyRoles[role].Name, memberName)
+			err = SetApplicationUserContext(context.Background(), iq, dummyApps[dummyIdx].PublicID, dummyRoles[role].Name, memberName)
 		case MemberTypeGroup:
-			err = SetApplicationGroup(iq, dummyApps[dummyIdx].PublicID, dummyRoles[role].Name, memberName)
+			err = SetApplicationGroupContext(context.Background(), iq, dummyApps[dummyIdx].PublicID, dummyRoles[role].Name, memberName)
 		}
 		if err == nil {
-			got, err = ApplicationAuthorizations(iq, dummyApps[dummyIdx].PublicID)
+			got, err = ApplicationAuthorizationsContext(context.Background(), iq, dummyApps[dummyIdx].PublicID)
 		}
 	}
 	if err != nil {
@@ -613,68 +614,68 @@ func testRevoke(t *testing.T, iq IQ, authType, memberType string) {
 		dummyOrgName := dummyOrgs[0].Name
 		switch memberType {
 		case MemberTypeUser:
-			err = SetOrganizationUser(iq, dummyOrgName, role.Name, name)
+			err = SetOrganizationUserContext(context.Background(), iq, dummyOrgName, role.Name, name)
 			if err == nil {
-				err = RevokeOrganizationUser(iq, dummyOrgName, role.Name, name)
+				err = RevokeOrganizationUserContext(context.Background(), iq, dummyOrgName, role.Name, name)
 			}
 		case MemberTypeGroup:
-			err = SetOrganizationGroup(iq, dummyOrgName, role.Name, name)
+			err = SetOrganizationGroupContext(context.Background(), iq, dummyOrgName, role.Name, name)
 			if err == nil {
 				t.Log("HERE1")
-				err = RevokeOrganizationGroup(iq, dummyOrgName, role.Name, name)
+				err = RevokeOrganizationGroupContext(context.Background(), iq, dummyOrgName, role.Name, name)
 			}
 		}
 		if err == nil {
-			mappings, err = OrganizationAuthorizations(iq, dummyOrgName)
+			mappings, err = OrganizationAuthorizationsContext(context.Background(), iq, dummyOrgName)
 		}
 	case "application":
 		dummyAppName := dummyApps[0].PublicID
 		switch memberType {
 		case MemberTypeUser:
-			err = SetApplicationUser(iq, dummyAppName, role.Name, name)
+			err = SetApplicationUserContext(context.Background(), iq, dummyAppName, role.Name, name)
 			if err == nil {
-				err = RevokeApplicationUser(iq, dummyAppName, role.Name, name)
+				err = RevokeApplicationUserContext(context.Background(), iq, dummyAppName, role.Name, name)
 			}
 		case MemberTypeGroup:
-			err = SetApplicationGroup(iq, dummyAppName, role.Name, name)
+			err = SetApplicationGroupContext(context.Background(), iq, dummyAppName, role.Name, name)
 			if err == nil {
-				err = RevokeApplicationGroup(iq, dummyAppName, role.Name, name)
+				err = RevokeApplicationGroupContext(context.Background(), iq, dummyAppName, role.Name, name)
 			}
 		}
 		if err == nil {
-			mappings, err = ApplicationAuthorizations(iq, dummyAppName)
+			mappings, err = ApplicationAuthorizationsContext(context.Background(), iq, dummyAppName)
 		}
 	case "repository_container":
 		switch memberType {
 		case MemberTypeUser:
-			err = SetRepositoriesUser(iq, role.Name, name)
+			err = SetRepositoriesUserContext(context.Background(), iq, role.Name, name)
 			if err == nil {
-				err = RevokeRepositoriesUser(iq, role.Name, name)
+				err = RevokeRepositoriesUserContext(context.Background(), iq, role.Name, name)
 			}
 		case MemberTypeGroup:
-			err = SetRepositoriesGroup(iq, role.Name, name)
+			err = SetRepositoriesGroupContext(context.Background(), iq, role.Name, name)
 			if err == nil {
-				err = RevokeRepositoriesGroup(iq, role.Name, name)
+				err = RevokeRepositoriesGroupContext(context.Background(), iq, role.Name, name)
 			}
 		}
 		if err == nil {
-			mappings, err = RepositoriesAuthorizations(iq)
+			mappings, err = RepositoriesAuthorizationsContext(context.Background(), iq)
 		}
 	case "global":
 		switch memberType {
 		case MemberTypeUser:
-			err = SetGlobalUser(iq, role.Name, name)
+			err = SetGlobalUserContext(context.Background(), iq, role.Name, name)
 			if err == nil {
-				err = RevokeGlobalUser(iq, role.Name, name)
+				err = RevokeGlobalUserContext(context.Background(), iq, role.Name, name)
 			}
 		case MemberTypeGroup:
-			err = SetGlobalGroup(iq, role.Name, name)
+			err = SetGlobalGroupContext(context.Background(), iq, role.Name, name)
 			if err == nil {
-				err = RevokeGlobalGroup(iq, role.Name, name)
+				err = RevokeGlobalGroupContext(context.Background(), iq, role.Name, name)
 			}
 		}
 		if err == nil {
-			mappings, err = GlobalAuthorizations(iq)
+			mappings, err = GlobalAuthorizationsContext(context.Background(), iq)
 		}
 	}
 	if err != nil {
@@ -732,7 +733,7 @@ func TestRepositoriesAuthorizations(t *testing.T) {
 	iq, mock := roleMembershipsTestIQ(t, false)
 	defer mock.Close()
 
-	got, err := RepositoriesAuthorizations(iq)
+	got, err := RepositoriesAuthorizationsContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -758,7 +759,7 @@ func TestGetApplicationAuthorizationsByRole(t *testing.T) {
 		}
 	}
 
-	got, err := RepositoriesAuthorizationsByRole(iq, role.Name)
+	got, err := RepositoriesAuthorizationsByRoleContext(context.Background(), iq, role.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -791,15 +792,15 @@ func testSetRepositories(t *testing.T, memberType string) {
 	var err error
 	switch memberType {
 	case MemberTypeUser:
-		err = SetRepositoriesUser(iq, role.Name, memberName)
+		err = SetRepositoriesUserContext(context.Background(), iq, role.Name, memberName)
 	case MemberTypeGroup:
-		err = SetRepositoriesGroup(iq, role.Name, memberName)
+		err = SetRepositoriesGroupContext(context.Background(), iq, role.Name, memberName)
 	}
 	if err != nil {
 		t.Error(err)
 	}
 
-	got, err := RepositoriesAuthorizations(iq)
+	got, err := RepositoriesAuthorizationsContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -860,7 +861,7 @@ func testMembersByRole(t *testing.T, iq IQ) {
 			}
 		}
 	}
-	if hasRev70API(iq) {
+	if hasRev70API(context.Background(), iq) {
 		for _, m := range dummyRoleMappingsRepos {
 			if m.RoleID == role.ID {
 				want = append(want, m)
@@ -868,7 +869,7 @@ func testMembersByRole(t *testing.T, iq IQ) {
 		}
 	}
 
-	got, err := MembersByRole(iq, role.Name)
+	got, err := MembersByRoleContext(context.Background(), iq, role.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -888,7 +889,7 @@ func TestGlobalAuthorizations(t *testing.T) {
 	iq, mock := roleMembershipsTestIQ(t, false)
 	defer mock.Close()
 
-	got, err := GlobalAuthorizations(iq)
+	got, err := GlobalAuthorizationsContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -924,15 +925,15 @@ func testSetGlobal(t *testing.T, memberType string) {
 	var err error
 	switch memberType {
 	case MemberTypeUser:
-		err = SetGlobalUser(iq, role.Name, memberName)
+		err = SetGlobalUserContext(context.Background(), iq, role.Name, memberName)
 	case MemberTypeGroup:
-		err = SetGlobalGroup(iq, role.Name, memberName)
+		err = SetGlobalGroupContext(context.Background(), iq, role.Name, memberName)
 	}
 	if err != nil {
 		t.Error(err)
 	}
 
-	got, err := GlobalAuthorizations(iq)
+	got, err := GlobalAuthorizationsContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/roles.go
+++ b/iq/roles.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -22,11 +23,10 @@ type Role struct {
 	Description string `json:"description"`
 }
 
-// Roles returns a slice of all the roles in the IQ instance
-func Roles(iq IQ) ([]Role, error) {
-	body, resp, err := iq.Get(restRoles)
+func RolesContext(ctx context.Context, iq IQ) ([]Role, error) {
+	body, resp, err := iq.Get(ctx, restRoles)
 	if resp.StatusCode == http.StatusNotFound {
-		body, _, err = iq.Get(restRolesDeprecated)
+		body, _, err = iq.Get(ctx, restRolesDeprecated)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve roles: %v", err)
@@ -40,9 +40,13 @@ func Roles(iq IQ) ([]Role, error) {
 	return list.Roles, nil
 }
 
-// RoleByName returns the named role
-func RoleByName(iq IQ, name string) (Role, error) {
-	roles, err := Roles(iq)
+// Roles returns a slice of all the roles in the IQ instance
+func Roles(iq IQ) ([]Role, error) {
+	return RolesContext(context.Background(), iq)
+}
+
+func RoleByNameContext(ctx context.Context, iq IQ, name string) (Role, error) {
+	roles, err := RolesContext(ctx, iq)
 	if err != nil {
 		return Role{}, fmt.Errorf("did not find role with name %s: %v", name, err)
 	}
@@ -56,12 +60,21 @@ func RoleByName(iq IQ, name string) (Role, error) {
 	return Role{}, fmt.Errorf("did not find role with name %s", name)
 }
 
-// GetSystemAdminID returns the identifier of the System Administrator role
-func GetSystemAdminID(iq IQ) (string, error) {
-	role, err := RoleByName(iq, "System Administrator")
+// RoleByName returns the named role
+func RoleByName(iq IQ, name string) (Role, error) {
+	return RoleByNameContext(context.Background(), iq, name)
+}
+
+func GetSystemAdminIDContext(ctx context.Context, iq IQ) (string, error) {
+	role, err := RoleByNameContext(ctx, iq, "System Administrator")
 	if err != nil {
 		return "", fmt.Errorf("did not get admin role: %v", err)
 	}
 
 	return role.ID, nil
+}
+
+// GetSystemAdminID returns the identifier of the System Administrator role
+func GetSystemAdminID(iq IQ) (string, error) {
+	return GetSystemAdminIDContext(context.Background(), iq)
 }

--- a/iq/roles_test.go
+++ b/iq/roles_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -80,7 +81,7 @@ func TestRoles(t *testing.T) {
 	iq, mock := rolesTestIQ(t)
 	defer mock.Close()
 
-	got, err := Roles(iq)
+	got, err := RolesContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +97,7 @@ func TestRoleByName(t *testing.T) {
 
 	want := dummyRoles[0]
 
-	got, err := RoleByName(iq, want.Name)
+	got, err := RoleByNameContext(context.Background(), iq, want.Name)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iq/search.go
+++ b/iq/search.go
@@ -2,6 +2,7 @@ package nexusiq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -117,10 +118,9 @@ func NewSearchQueryBuilder() *SearchQueryBuilder {
 	return b
 }
 
-// SearchComponents allows searching the indicated IQ instance for specific components
-func SearchComponents(iq IQ, query nexus.SearchQueryBuilder) ([]SearchResult, error) {
+func SearchComponentsContext(ctx context.Context, iq IQ, query nexus.SearchQueryBuilder) ([]SearchResult, error) {
 	endpoint := restSearchComponent + "?" + query.Build()
-	body, resp, err := iq.Get(endpoint)
+	body, resp, err := iq.Get(ctx, endpoint)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("could not find component: %v", err)
 	}
@@ -131,4 +131,9 @@ func SearchComponents(iq IQ, query nexus.SearchQueryBuilder) ([]SearchResult, er
 	}
 
 	return searchResp.Results, nil
+}
+
+// SearchComponents allows searching the indicated IQ instance for specific components
+func SearchComponents(iq IQ, query nexus.SearchQueryBuilder) ([]SearchResult, error) {
+	return SearchComponentsContext(context.Background(), iq, query)
 }

--- a/iq/search_test.go
+++ b/iq/search_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -57,7 +58,7 @@ func TestSearchComponent(t *testing.T) {
 	defer mock.Close()
 
 	query := NewSearchQueryBuilder().Coordinates(dummyComponent.ComponentID.Coordinates)
-	components, err := SearchComponents(iq, query)
+	components, err := SearchComponentsContext(context.Background(), iq, query)
 	if err != nil {
 		t.Fatalf("Did not complete search: %v", err)
 	}
@@ -88,7 +89,7 @@ func ExampleSearchComponents() {
 	query = query.Stage(StageBuild)
 	query = query.PackageURL("pkg:maven/commons-collections/commons-collections@3.2")
 
-	components, err := SearchComponents(iq, query)
+	components, err := SearchComponentsContext(context.Background(), iq, query)
 	if err != nil {
 		panic(fmt.Sprintf("Did not complete search: %v", err))
 	}

--- a/iq/sourceControl.go
+++ b/iq/sourceControl.go
@@ -2,6 +2,7 @@ package nexusiq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -20,10 +21,10 @@ type SourceControlEntry struct {
 	Token         string `json:"token"`
 }
 
-func getSourceControlEntryByInternalID(iq IQ, applicationID string) (entry SourceControlEntry, err error) {
+func getSourceControlEntryByInternalID(ctx context.Context, iq IQ, applicationID string) (entry SourceControlEntry, err error) {
 	endpoint := fmt.Sprintf(restSourceControl, applicationID)
 
-	body, _, err := iq.Get(endpoint)
+	body, _, err := iq.Get(ctx, endpoint)
 	if err != nil {
 		return
 	}
@@ -33,26 +34,29 @@ func getSourceControlEntryByInternalID(iq IQ, applicationID string) (entry Sourc
 	return
 }
 
-// GetSourceControlEntry lists of all of the Source Control entries for the given application
-func GetSourceControlEntry(iq IQ, applicationID string) (SourceControlEntry, error) {
-	appInfo, err := GetApplicationByPublicID(iq, applicationID)
+func GetSourceControlEntryContext(ctx context.Context, iq IQ, applicationID string) (SourceControlEntry, error) {
+	appInfo, err := GetApplicationByPublicIDContext(ctx, iq, applicationID)
 	if err != nil {
 		return SourceControlEntry{}, fmt.Errorf("no source control entry for '%s': %v", applicationID, err)
 	}
 
-	return getSourceControlEntryByInternalID(iq, appInfo.ID)
+	return getSourceControlEntryByInternalID(ctx, iq, appInfo.ID)
 }
 
-// GetAllSourceControlEntries lists of all of the Source Control entries in the IQ instance
-func GetAllSourceControlEntries(iq IQ) ([]SourceControlEntry, error) {
-	apps, err := GetAllApplications(iq)
+// GetSourceControlEntry lists of all of the Source Control entries for the given application
+func GetSourceControlEntry(iq IQ, applicationID string) (SourceControlEntry, error) {
+	return GetSourceControlEntryContext(context.Background(), iq, applicationID)
+}
+
+func GetAllSourceControlEntriesContext(ctx context.Context, iq IQ) ([]SourceControlEntry, error) {
+	apps, err := GetAllApplicationsContext(ctx, iq)
 	if err != nil {
 		return nil, fmt.Errorf("no source control entries: %v", err)
 	}
 
 	entries := make([]SourceControlEntry, 0)
 	for _, app := range apps {
-		if entry, err := getSourceControlEntryByInternalID(iq, app.ID); err == nil {
+		if entry, err := getSourceControlEntryByInternalID(ctx, iq, app.ID); err == nil {
 			entries = append(entries, entry)
 		}
 	}
@@ -60,13 +64,17 @@ func GetAllSourceControlEntries(iq IQ) ([]SourceControlEntry, error) {
 	return entries, nil
 }
 
-// CreateSourceControlEntry creates a source control entry in IQ
-func CreateSourceControlEntry(iq IQ, applicationID, repositoryURL, token string) error {
+// GetAllSourceControlEntries lists of all of the Source Control entries in the IQ instance
+func GetAllSourceControlEntries(iq IQ) ([]SourceControlEntry, error) {
+	return GetAllSourceControlEntriesContext(context.Background(), iq)
+}
+
+func CreateSourceControlEntryContext(ctx context.Context, iq IQ, applicationID, repositoryURL, token string) error {
 	doError := func(err error) error {
 		return fmt.Errorf("source control entry not created for '%s': %v", applicationID, err)
 	}
 
-	appInfo, err := GetApplicationByPublicID(iq, applicationID)
+	appInfo, err := GetApplicationByPublicIDContext(ctx, iq, applicationID)
 	if err != nil {
 		return doError(err)
 	}
@@ -77,7 +85,35 @@ func CreateSourceControlEntry(iq IQ, applicationID, repositoryURL, token string)
 	}
 
 	endpoint := fmt.Sprintf(restSourceControl, appInfo.ID)
-	if _, _, err = iq.Post(endpoint, bytes.NewBuffer(request)); err != nil {
+	if _, _, err = iq.Post(ctx, endpoint, bytes.NewBuffer(request)); err != nil {
+		return doError(err)
+	}
+
+	return nil
+}
+
+// CreateSourceControlEntry creates a source control entry in IQ
+func CreateSourceControlEntry(iq IQ, applicationID, repositoryURL, token string) error {
+	return CreateSourceControlEntryContext(context.Background(), iq, applicationID, repositoryURL, token)
+}
+
+func UpdateSourceControlEntryContext(ctx context.Context, iq IQ, applicationID, repositoryURL, token string) error {
+	doError := func(err error) error {
+		return fmt.Errorf("source control entry not updated for '%s': %v", applicationID, err)
+	}
+
+	appInfo, err := GetApplicationByPublicIDContext(ctx, iq, applicationID)
+	if err != nil {
+		return doError(err)
+	}
+
+	request, err := json.Marshal(SourceControlEntry{"", appInfo.ID, repositoryURL, token})
+	if err != nil {
+		return doError(err)
+	}
+
+	endpoint := fmt.Sprintf(restSourceControl, appInfo.ID)
+	if _, _, err = iq.Put(ctx, endpoint, bytes.NewBuffer(request)); err != nil {
 		return doError(err)
 	}
 
@@ -86,32 +122,13 @@ func CreateSourceControlEntry(iq IQ, applicationID, repositoryURL, token string)
 
 // UpdateSourceControlEntry updates a source control entry in IQ
 func UpdateSourceControlEntry(iq IQ, applicationID, repositoryURL, token string) error {
-	doError := func(err error) error {
-		return fmt.Errorf("source control entry not updated for '%s': %v", applicationID, err)
-	}
-
-	appInfo, err := GetApplicationByPublicID(iq, applicationID)
-	if err != nil {
-		return doError(err)
-	}
-
-	request, err := json.Marshal(SourceControlEntry{"", appInfo.ID, repositoryURL, token})
-	if err != nil {
-		return doError(err)
-	}
-
-	endpoint := fmt.Sprintf(restSourceControl, appInfo.ID)
-	if _, _, err = iq.Put(endpoint, bytes.NewBuffer(request)); err != nil {
-		return doError(err)
-	}
-
-	return nil
+	return UpdateSourceControlEntryContext(context.Background(), iq, applicationID, repositoryURL, token)
 }
 
-func deleteSourceControlEntry(iq IQ, appInternalID, sourceControlID string) error {
+func deleteSourceControlEntry(ctx context.Context, iq IQ, appInternalID, sourceControlID string) error {
 	endpoint := fmt.Sprintf(restSourceControlDelete, appInternalID, sourceControlID)
 
-	resp, err := iq.Del(endpoint)
+	resp, err := iq.Del(ctx, endpoint)
 	if err != nil && resp.StatusCode != http.StatusNoContent {
 		return err
 	}
@@ -119,33 +136,41 @@ func deleteSourceControlEntry(iq IQ, appInternalID, sourceControlID string) erro
 	return nil
 }
 
-// DeleteSourceControlEntry deletes a source control entry in IQ
-func DeleteSourceControlEntry(iq IQ, applicationID, sourceControlID string) error {
-	appInfo, err := GetApplicationByPublicID(iq, applicationID)
+func DeleteSourceControlEntryContext(ctx context.Context, iq IQ, applicationID, sourceControlID string) error {
+	appInfo, err := GetApplicationByPublicIDContext(ctx, iq, applicationID)
 	if err != nil {
 		return fmt.Errorf("source control entry not deleted from '%s': %v", applicationID, err)
 	}
 
-	return deleteSourceControlEntry(iq, appInfo.ID, sourceControlID)
+	return deleteSourceControlEntry(ctx, iq, appInfo.ID, sourceControlID)
 }
 
-// DeleteSourceControlEntryByApp deletes a source control entry in IQ for the given application
-func DeleteSourceControlEntryByApp(iq IQ, applicationID string) error {
+// DeleteSourceControlEntry deletes a source control entry in IQ
+func DeleteSourceControlEntry(iq IQ, applicationID, sourceControlID string) error {
+	return DeleteSourceControlEntryContext(context.Background(), iq, applicationID, sourceControlID)
+}
+
+func DeleteSourceControlEntryByAppContext(ctx context.Context, iq IQ, applicationID string) error {
 	doError := func(err error) error {
 		return fmt.Errorf("source control entry not deleted from '%s': %v", applicationID, err)
 	}
 
-	appInfo, err := GetApplicationByPublicID(iq, applicationID)
+	appInfo, err := GetApplicationByPublicIDContext(ctx, iq, applicationID)
 	if err != nil {
 		return doError(err)
 	}
 
-	entry, err := getSourceControlEntryByInternalID(iq, appInfo.ID)
+	entry, err := getSourceControlEntryByInternalID(ctx, iq, appInfo.ID)
 	if err != nil {
 		return doError(err)
 	}
 
-	return deleteSourceControlEntry(iq, appInfo.ID, entry.ID)
+	return deleteSourceControlEntry(ctx, iq, appInfo.ID, entry.ID)
+}
+
+// DeleteSourceControlEntryByApp deletes a source control entry in IQ for the given application
+func DeleteSourceControlEntryByApp(iq IQ, applicationID string) error {
+	return DeleteSourceControlEntryByAppContext(context.Background(), iq, applicationID)
 }
 
 // DeleteSourceControlEntryByEntry deletes a source control entry in IQ for the given entry ID

--- a/iq/sourceControl_test.go
+++ b/iq/sourceControl_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -115,7 +116,7 @@ func TestGetSourceControlEntryByInternalID(t *testing.T) {
 
 	dummyEntryIdx := 2
 
-	entry, err := getSourceControlEntryByInternalID(iq, dummyEntries[dummyEntryIdx].ApplicationID)
+	entry, err := getSourceControlEntryByInternalID(context.Background(), iq, dummyEntries[dummyEntryIdx].ApplicationID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -131,7 +132,7 @@ func TestGetAllSourceControlEntries(t *testing.T) {
 	iq, mock := sourceControlTestIQ(t)
 	defer mock.Close()
 
-	entries, err := GetAllSourceControlEntries(iq)
+	entries, err := GetAllSourceControlEntriesContext(context.Background(), iq)
 	if err != nil {
 		t.Error(err)
 	}
@@ -161,7 +162,7 @@ func TestGetSourceControlEntry(t *testing.T) {
 
 	dummyEntryIdx := 0
 
-	entry, err := GetSourceControlEntry(iq, dummyApps[dummyEntryIdx].PublicID)
+	entry, err := GetSourceControlEntryContext(context.Background(), iq, dummyApps[dummyEntryIdx].PublicID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -179,12 +180,12 @@ func TestCreateSourceControlEntry(t *testing.T) {
 
 	createdEntry := SourceControlEntry{newEntryID, dummyApps[len(dummyApps)-1].ID, "createdEntryURL", "createEntryToken"}
 
-	err := CreateSourceControlEntry(iq, dummyApps[len(dummyApps)-1].PublicID, createdEntry.RepositoryURL, createdEntry.Token)
+	err := CreateSourceControlEntryContext(context.Background(), iq, dummyApps[len(dummyApps)-1].PublicID, createdEntry.RepositoryURL, createdEntry.Token)
 	if err != nil {
 		t.Error(err)
 	}
 
-	entry, err := GetSourceControlEntry(iq, dummyApps[len(dummyApps)-1].PublicID)
+	entry, err := GetSourceControlEntryContext(context.Background(), iq, dummyApps[len(dummyApps)-1].PublicID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -202,12 +203,12 @@ func TestUpdateSourceControlEntry(t *testing.T) {
 	updatedEntryRepositoryURL := "updatedRepoURL"
 	updatedEntryToken := "updatedToken"
 
-	err := UpdateSourceControlEntry(iq, dummyApps[len(dummyApps)-2].PublicID, updatedEntryRepositoryURL, updatedEntryToken)
+	err := UpdateSourceControlEntryContext(context.Background(), iq, dummyApps[len(dummyApps)-2].PublicID, updatedEntryRepositoryURL, updatedEntryToken)
 	if err != nil {
 		t.Error(err)
 	}
 
-	entry, err := GetSourceControlEntry(iq, dummyApps[len(dummyApps)-2].PublicID)
+	entry, err := GetSourceControlEntryContext(context.Background(), iq, dummyApps[len(dummyApps)-2].PublicID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -229,15 +230,15 @@ func TestDeleteSourceControlEntry(t *testing.T) {
 	app := dummyApps[len(dummyApps)-1]
 	deleteMe := SourceControlEntry{newEntryID, app.ID, "deleteMeURL", "deleteMeToken"}
 
-	if err := CreateSourceControlEntry(iq, app.PublicID, deleteMe.RepositoryURL, deleteMe.Token); err != nil {
+	if err := CreateSourceControlEntryContext(context.Background(), iq, app.PublicID, deleteMe.RepositoryURL, deleteMe.Token); err != nil {
 		t.Error(err)
 	}
 
-	if err := DeleteSourceControlEntry(iq, app.PublicID, newEntryID); err != nil {
+	if err := DeleteSourceControlEntryContext(context.Background(), iq, app.PublicID, newEntryID); err != nil {
 		t.Error(err)
 	}
 
-	if _, err := GetSourceControlEntry(iq, app.PublicID); err == nil {
+	if _, err := GetSourceControlEntryContext(context.Background(), iq, app.PublicID); err == nil {
 		t.Error("Unexpectedly found entry which should have been deleted")
 	}
 }
@@ -249,15 +250,15 @@ func TestDeleteSourceControlEntryByApp(t *testing.T) {
 	app := dummyApps[len(dummyApps)-1]
 	deleteMe := SourceControlEntry{newEntryID, app.ID, "deleteMeURL", "deleteMeToken"}
 
-	if err := CreateSourceControlEntry(iq, app.PublicID, deleteMe.RepositoryURL, deleteMe.Token); err != nil {
+	if err := CreateSourceControlEntryContext(context.Background(), iq, app.PublicID, deleteMe.RepositoryURL, deleteMe.Token); err != nil {
 		t.Error(err)
 	}
 
-	if err := DeleteSourceControlEntryByApp(iq, app.PublicID); err != nil {
+	if err := DeleteSourceControlEntryByAppContext(context.Background(), iq, app.PublicID); err != nil {
 		t.Error(err)
 	}
 
-	if _, err := GetSourceControlEntry(iq, app.PublicID); err == nil {
+	if _, err := GetSourceControlEntryContext(context.Background(), iq, app.PublicID); err == nil {
 		t.Error("Unexpectedly found entry which should have been deleted")
 	}
 }

--- a/iq/users.go
+++ b/iq/users.go
@@ -2,6 +2,7 @@ package nexusiq
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -21,10 +22,9 @@ type User struct {
 	Password  string `json:"password,omitempty"`
 }
 
-// GetUser returns user details for the given name
-func GetUser(iq IQ, username string) (user User, err error) {
+func GetUserContext(ctx context.Context, iq IQ, username string) (user User, err error) {
 	endpoint := fmt.Sprintf(restUsers, username)
-	body, _, err := iq.Get(endpoint)
+	body, _, err := iq.Get(ctx, endpoint)
 	if err != nil {
 		return user, fmt.Errorf("could not retrieve details on username %s: %v", username, err)
 	}
@@ -34,32 +34,45 @@ func GetUser(iq IQ, username string) (user User, err error) {
 	return user, err
 }
 
-// SetUser creates a new user
-func SetUser(iq IQ, user User) (err error) {
+// GetUser returns user details for the given name
+func GetUser(iq IQ, username string) (user User, err error) {
+	return GetUserContext(context.Background(), iq, username)
+}
+
+func SetUserContext(ctx context.Context, iq IQ, user User) (err error) {
 	buf, err := json.Marshal(user)
 	if err != nil {
 		return fmt.Errorf("could not read user details: %v", err)
 	}
 	str := bytes.NewBuffer(buf)
 
-	if _, er := GetUser(iq, user.Username); er != nil {
-		_, resp, er := iq.Post(restUsersPost, str)
+	if _, er := GetUserContext(ctx, iq, user.Username); er != nil {
+		_, resp, er := iq.Post(ctx, restUsersPost, str)
 		if er != nil && resp.StatusCode != http.StatusNoContent {
 			return er
 		}
 	} else {
 		endpoint := fmt.Sprintf(restUsers, user.Username)
-		_, _, err = iq.Put(endpoint, str)
+		_, _, err = iq.Put(ctx, endpoint, str)
 	}
 
 	return err
 }
 
-// DeleteUser removes the named user
-func DeleteUser(iq IQ, username string) error {
+// SetUser creates a new user
+func SetUser(iq IQ, user User) (err error) {
+	return SetUserContext(context.Background(), iq, user)
+}
+
+func DeleteUserContext(ctx context.Context, iq IQ, username string) error {
 	endpoint := fmt.Sprintf(restUsers, username)
-	if resp, err := iq.Del(endpoint); err != nil && resp.StatusCode != http.StatusNoContent {
+	if resp, err := iq.Del(ctx, endpoint); err != nil && resp.StatusCode != http.StatusNoContent {
 		return err
 	}
 	return nil
+}
+
+// DeleteUser removes the named user
+func DeleteUser(iq IQ, username string) error {
+	return DeleteUserContext(context.Background(), iq, username)
 }

--- a/iq/users_test.go
+++ b/iq/users_test.go
@@ -1,6 +1,7 @@
 package nexusiq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -145,7 +146,7 @@ func usersTestIQ(t *testing.T, useDeprecated bool) (IQ, *httptest.Server) {
 
 func checkExists(t *testing.T, iq IQ, want User) {
 	t.Helper()
-	got, err := GetUser(iq, want.Username)
+	got, err := GetUserContext(context.Background(), iq, want.Username)
 	if err != nil {
 		t.Error(err)
 	}
@@ -165,7 +166,7 @@ func TestGetUser(t *testing.T) {
 }
 
 func setUser(t *testing.T, iq IQ, want User) {
-	err := SetUser(iq, want)
+	err := SetUserContext(context.Background(), iq, want)
 	if err != nil {
 		t.Error(err)
 	}
@@ -234,12 +235,12 @@ func TestDeleteUser(t *testing.T) {
 	// Create new dummy user
 	setUser(t, iq, want)
 
-	err := DeleteUser(iq, want.Username)
+	err := DeleteUserContext(context.Background(), iq, want.Username)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if _, err := GetUser(iq, want.Username); err == nil {
+	if _, err := GetUserContext(context.Background(), iq, want.Username); err == nil {
 		t.Error("Found user which I tried to delete")
 	}
 }

--- a/rm/anonymous.go
+++ b/rm/anonymous.go
@@ -2,6 +2,7 @@ package nexusrm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,10 +16,10 @@ type SettingsAnonAccess struct {
 	RealmName string `json:"realmName"`
 }
 
-func GetAnonAccess(rm RM) (SettingsAnonAccess, error) {
+func GetAnonAccessContext(ctx context.Context, rm RM) (SettingsAnonAccess, error) {
 	var settings SettingsAnonAccess
 
-	body, resp, err := rm.Get(restAnonymous)
+	body, resp, err := rm.Get(ctx, restAnonymous)
 	if err != nil && resp.StatusCode != http.StatusNoContent {
 		return SettingsAnonAccess{}, fmt.Errorf("anonymous access settings can't getting: %v", err)
 	}
@@ -30,15 +31,23 @@ func GetAnonAccess(rm RM) (SettingsAnonAccess, error) {
 	return settings, nil
 }
 
-func SetAnonAccess(rm RM, settings SettingsAnonAccess) error {
+func GetAnonAccess(rm RM) (SettingsAnonAccess, error) {
+	return GetAnonAccessContext(context.Background(), rm)
+}
+
+func SetAnonAccessContext(ctx context.Context, rm RM, settings SettingsAnonAccess) error {
 	json, err := json.Marshal(settings)
 	if err != nil {
 		return err
 	}
 
-	if _, resp, err := rm.Put(restAnonymous, bytes.NewBuffer(json)); err != nil && resp.StatusCode != http.StatusNoContent {
+	if _, resp, err := rm.Put(ctx, restAnonymous, bytes.NewBuffer(json)); err != nil && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("email config not set: %v", err)
 	}
 
 	return nil
+}
+
+func SetAnonAccess(rm RM, settings SettingsAnonAccess) error {
+	return SetAnonAccessContext(context.Background(), rm, settings)
 }

--- a/rm/assets_test.go
+++ b/rm/assets_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -130,7 +131,7 @@ func getAssetsTester(t *testing.T, repo string) {
 	rm, mock := assetsTestRM(t)
 	defer mock.Close()
 
-	assets, err := GetAssets(rm, repo)
+	assets, err := GetAssetsContext(context.Background(), rm, repo)
 	if err != nil {
 		panic(err)
 	}
@@ -162,7 +163,7 @@ func TestGetAssetByID(t *testing.T) {
 
 	expectedAsset := dummyAssets["repo-maven"][0]
 
-	asset, err := GetAssetByID(rm, expectedAsset.ID)
+	asset, err := GetAssetByIDContext(context.Background(), rm, expectedAsset.ID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -189,15 +190,15 @@ func TestDeleteAssetByID(t *testing.T) {
 
 	dummyAssets[deleteMe.Repository] = append(dummyAssets[deleteMe.Repository], deleteMe)
 
-	if _, err := GetAssetByID(rm, deleteMe.ID); err != nil {
+	if _, err := GetAssetByIDContext(context.Background(), rm, deleteMe.ID); err != nil {
 		t.Errorf("Error getting component: %v\n", err)
 	}
 
-	if err := DeleteAssetByID(rm, deleteMe.ID); err != nil {
+	if err := DeleteAssetByIDContext(context.Background(), rm, deleteMe.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := GetAssetByID(rm, deleteMe.ID); err == nil {
+	if _, err := GetAssetByIDContext(context.Background(), rm, deleteMe.ID); err == nil {
 		t.Errorf("Asset not deleted: %v\n", err)
 	}
 }

--- a/rm/components_test.go
+++ b/rm/components_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -168,7 +169,7 @@ func getComponentsTester(t *testing.T, repo string) {
 	rm, mock := componentsTestRM(t)
 	defer mock.Close()
 
-	components, err := GetComponents(rm, repo)
+	components, err := GetComponentsContext(context.Background(), rm, repo)
 	if err != nil {
 		panic(err)
 	}
@@ -200,7 +201,7 @@ func TestGetComponentByID(t *testing.T) {
 
 	expectedComponent := dummyComponents["repo-maven"][0]
 
-	component, err := GetComponentByID(rm, expectedComponent.ID)
+	component, err := GetComponentByIDContext(context.Background(), rm, expectedComponent.ID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -218,13 +219,13 @@ func componentUploader(t *testing.T, expected RepositoryItem, upload UploadCompo
 	defer mock.Close()
 
 	// if err := UploadComponent(rm, expected.Repository, coordinate, file); err != nil {
-	if err := UploadComponent(rm, expected.Repository, upload); err != nil {
+	if err := UploadComponentContext(context.Background(), rm, expected.Repository, upload); err != nil {
 		t.Error(err)
 	}
 
 	expected.ID = dummyNewComponentID
 
-	component, err := GetComponentByID(rm, expected.ID)
+	component, err := GetComponentByIDContext(context.Background(), rm, expected.ID)
 	if err != nil {
 		t.Error(err)
 	}
@@ -314,17 +315,17 @@ func TestDeleteComponentByID(t *testing.T) {
 	}
 
 	// if err = UploadComponent(rm, deleteMe.Repository, coord, nil); err != nil {
-	if err = UploadComponent(rm, deleteMe.Repository, upload); err != nil {
+	if err = UploadComponentContext(context.Background(), rm, deleteMe.Repository, upload); err != nil {
 		t.Error(err)
 	}
 
 	deleteMe.ID = dummyNewComponentID
 
-	if err = DeleteComponentByID(rm, deleteMe.ID); err != nil {
+	if err = DeleteComponentByIDContext(context.Background(), rm, deleteMe.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := GetComponentByID(rm, deleteMe.ID); err == nil {
+	if _, err := GetComponentByIDContext(context.Background(), rm, deleteMe.ID); err == nil {
 		t.Errorf("Component not deleted: %v\n", err)
 	}
 }
@@ -335,7 +336,7 @@ func ExampleGetComponents() {
 		panic(err)
 	}
 
-	items, err := GetComponents(rm, "maven-central")
+	items, err := GetComponentsContext(context.Background(), rm, "maven-central")
 	if err != nil {
 		panic(err)
 	}

--- a/rm/email.go
+++ b/rm/email.go
@@ -2,6 +2,7 @@ package nexusrm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,24 +25,27 @@ type EmailConfig struct {
 	NexusTrustStoreEnabled        bool   `json:"nexusTrustStoreEnabled"`
 }
 
-func SetEmailConfig(rm RM, config EmailConfig) error {
-
+func SetEmailConfigContext(ctx context.Context, rm RM, config EmailConfig) error {
 	json, err := json.Marshal(config)
 	if err != nil {
 		return err
 	}
 
-	if _, resp, err := rm.Put(restEmail, bytes.NewBuffer(json)); err != nil && resp.StatusCode != http.StatusNoContent {
+	if _, resp, err := rm.Put(ctx, restEmail, bytes.NewBuffer(json)); err != nil && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("email config not set: %v", err)
 	}
 
 	return nil
 }
 
-func GetEmailConfig(rm RM) (EmailConfig, error) {
+func SetEmailConfig(rm RM, config EmailConfig) error {
+	return SetEmailConfigContext(context.Background(), rm, config)
+}
+
+func GetEmailConfigContext(ctx context.Context, rm RM) (EmailConfig, error) {
 	var config EmailConfig
 
-	body, resp, err := rm.Get(restEmail)
+	body, resp, err := rm.Get(ctx, restEmail)
 	if err != nil && resp.StatusCode != http.StatusNoContent {
 		return EmailConfig{}, fmt.Errorf("email config can't getting: %v", err)
 	}
@@ -53,11 +57,18 @@ func GetEmailConfig(rm RM) (EmailConfig, error) {
 	return config, nil
 }
 
-func DeleteEmailConfig(rm RM) error {
+func GetEmailConfig(rm RM) (EmailConfig, error) {
+	return GetEmailConfigContext(context.Background(), rm)
+}
 
-	if resp, err := rm.Del(restEmail); err != nil && resp.StatusCode != http.StatusNoContent {
+func DeleteEmailConfigContext(ctx context.Context, rm RM) error {
+	if resp, err := rm.Del(ctx, restEmail); err != nil && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("email config not deleted: %v", err)
 	}
 
 	return nil
+}
+
+func DeleteEmailConfig(rm RM) error {
+	return DeleteEmailConfigContext(context.Background(), rm)
 }

--- a/rm/groovyBlobStore.go
+++ b/rm/groovyBlobStore.go
@@ -2,6 +2,7 @@ package nexusrm
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"text/template"
 )
@@ -54,13 +55,12 @@ func DeleteBlobStore(rm RM, name string) error {
 		return err
 	}
 
-	_, err = ScriptRunOnce(rm, newAnonGroovyScript(buf.String()), nil)
+	_, err = ScriptRunOnceContext(rm, newAnonGroovyScript(buf.String()), nil)
 	return err
 }
 */
 
-// CreateFileBlobStore creates a blobstore
-func CreateFileBlobStore(rm RM, name, path string) error {
+func CreateFileBlobStoreContext(ctx context.Context, rm RM, name, path string) error {
 	tmpl, err := template.New("fbs").Parse(groovyCreateFileBlobStore)
 	if err != nil {
 		return fmt.Errorf("could not parse template: %v", err)
@@ -72,12 +72,16 @@ func CreateFileBlobStore(rm RM, name, path string) error {
 		return fmt.Errorf("could not create file blobstore from template: %v", err)
 	}
 
-	_, err = ScriptRunOnce(rm, newAnonGroovyScript(buf.String()), nil)
+	_, err = ScriptRunOnceContext(ctx, rm, newAnonGroovyScript(buf.String()), nil)
 	return fmt.Errorf("could not create file blobstore: %v", err)
 }
 
-// CreateBlobStoreGroup creates a blobstore
-func CreateBlobStoreGroup(rm RM, name string, blobStores []string) error {
+// CreateFileBlobStore creates a blobstore
+func CreateFileBlobStore(rm RM, name, path string) error {
+	return CreateFileBlobStoreContext(context.Background(), rm, name, path)
+}
+
+func CreateBlobStoreGroupContext(ctx context.Context, rm RM, name string, blobStores []string) error {
 	tmpl, err := template.New("group").Parse(groovyCreateBlobStoreGroup)
 	if err != nil {
 		return fmt.Errorf("could not parse template: %v", err)
@@ -89,6 +93,11 @@ func CreateBlobStoreGroup(rm RM, name string, blobStores []string) error {
 		return fmt.Errorf("could not create group blobstore from template: %v", err)
 	}
 
-	_, err = ScriptRunOnce(rm, newAnonGroovyScript(buf.String()), nil)
+	_, err = ScriptRunOnceContext(ctx, rm, newAnonGroovyScript(buf.String()), nil)
 	return fmt.Errorf("could not create group blobstore: %v", err)
+}
+
+// CreateBlobStoreGroup creates a blobstore group
+func CreateBlobStoreGroup(rm RM, name string, blobStores []string) error {
+	return CreateBlobStoreGroupContext(context.Background(), rm, name, blobStores)
 }

--- a/rm/groovyBlobStore_test.go
+++ b/rm/groovyBlobStore_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"testing"
 )
 
@@ -9,7 +10,7 @@ func TestCreateFileBlobStore(t *testing.T) {
 	rm, mock := repositoriesTestRM(t)
 	defer mock.Close()
 
-	err := CreateFileBlobStore(rm, "testname", "testpath")
+	err := CreateFileBlobStoreContext(context.Background(), rm, "testname", "testpath")
 	if err != nil {
 		t.Error(err)
 	}
@@ -22,11 +23,11 @@ func TestCreateBlobStoreGroup(t *testing.T) {
 	rm, mock := repositoriesTestRM(t)
 	defer mock.Close()
 
-	CreateFileBlobStore(rm, "f1", "pathf1")
-	CreateFileBlobStore(rm, "f2", "pathf2")
-	CreateFileBlobStore(rm, "f3", "pathf3")
+	CreateFileBlobStoreContext(context.Background(), rm, "f1", "pathf1")
+	CreateFileBlobStoreContext(context.Background(), rm, "f2", "pathf2")
+	CreateFileBlobStoreContext(context.Background(), rm, "f3", "pathf3")
 
-	err := CreateBlobStoreGroup(rm, "grpname", []string{"f1", "f2", "f3"})
+	err := CreateBlobStoreGroupContext(context.Background(), rm, "grpname", []string{"f1", "f2", "f3"})
 	if err != nil {
 		t.Error(err)
 	}

--- a/rm/groovyRepository.go
+++ b/rm/groovyRepository.go
@@ -2,6 +2,7 @@ package nexusrm
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"text/template"
 )
@@ -71,8 +72,7 @@ type repositoryGroup struct {
 	Members         []string
 }
 
-// CreateHostedRepository creates a hosted repository of the indicated format
-func CreateHostedRepository(rm RM, format repositoryFormat, config repositoryHosted) error {
+func CreateHostedRepositoryContext(ctx context.Context, rm RM, format repositoryFormat, config repositoryHosted) error {
 	var groovyTmpl string
 	switch format {
 	case Maven:
@@ -112,12 +112,16 @@ func CreateHostedRepository(rm RM, format repositoryFormat, config repositoryHos
 		return fmt.Errorf("could not create hosted repository from template: %v", err)
 	}
 
-	_, err = ScriptRunOnce(rm, newAnonGroovyScript(buf.String()), nil)
+	_, err = ScriptRunOnceContext(ctx, rm, newAnonGroovyScript(buf.String()), nil)
 	return fmt.Errorf("could not create hosted repository: %v", err)
 }
 
-// CreateProxyRepository creates a proxy repository of the indicated format
-func CreateProxyRepository(rm RM, format repositoryFormat, config repositoryProxy) error {
+// CreateHostedRepository creates a hosted repository of the indicated format
+func CreateHostedRepository(rm RM, format repositoryFormat, config repositoryHosted) error {
+	return CreateHostedRepositoryContext(context.Background(), rm, format, config)
+}
+
+func CreateProxyRepositoryContext(ctx context.Context, rm RM, format repositoryFormat, config repositoryProxy) error {
 	var groovyTmpl string
 	switch format {
 	case Maven:
@@ -157,12 +161,16 @@ func CreateProxyRepository(rm RM, format repositoryFormat, config repositoryProx
 		return fmt.Errorf("could not create proxy repository from template: %v", err)
 	}
 
-	_, err = ScriptRunOnce(rm, newAnonGroovyScript(buf.String()), nil)
+	_, err = ScriptRunOnceContext(ctx, rm, newAnonGroovyScript(buf.String()), nil)
 	return fmt.Errorf("could not create proxy repository: %v", err)
 }
 
-// CreateGroupRepository creates a group repository of the indicated format
-func CreateGroupRepository(rm RM, format repositoryFormat, config repositoryGroup) error {
+// CreateProxyRepository creates a proxy repository of the indicated format
+func CreateProxyRepository(rm RM, format repositoryFormat, config repositoryProxy) error {
+	return CreateProxyRepositoryContext(context.Background(), rm, format, config)
+}
+
+func CreateGroupRepositoryContext(ctx context.Context, rm RM, format repositoryFormat, config repositoryGroup) error {
 	var groovyTmpl string
 	switch format {
 	case Maven:
@@ -202,6 +210,11 @@ func CreateGroupRepository(rm RM, format repositoryFormat, config repositoryGrou
 		return fmt.Errorf("could not create group repository from template: %v", err)
 	}
 
-	_, err = ScriptRunOnce(rm, newAnonGroovyScript(buf.String()), nil)
+	_, err = ScriptRunOnceContext(ctx, rm, newAnonGroovyScript(buf.String()), nil)
 	return fmt.Errorf("could not create group repository: %v", err)
+}
+
+// CreateGroupRepository creates a group repository of the indicated format
+func CreateGroupRepository(rm RM, format repositoryFormat, config repositoryGroup) error {
+	return CreateGroupRepositoryContext(context.Background(), rm, format, config)
 }

--- a/rm/groovyRepository_test.go
+++ b/rm/groovyRepository_test.go
@@ -1,16 +1,12 @@
 package nexusrm
 
-import (
-// "testing"
-)
-
 /*
 func TestCreateFileBlobStore(t *testing.T) {
 	t.Skip("Needs new framework")
 	rm, mock := repositoriesTestRM(t)
 	defer mock.Close()
 
-	err := CreateFileBlobStore(rm, "testname", "testpath")
+	err := CreateFileBlobStoreContext(rm, "testname", "testpath")
 	if err != nil {
 		t.Error(err)
 	}

--- a/rm/maintenance_test.go
+++ b/rm/maintenance_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,7 +51,7 @@ func TestCheckDatabase(t *testing.T) {
 
 	db := ComponentDB
 
-	state, err := CheckDatabase(rm, db)
+	state, err := CheckDatabaseContext(context.Background(), rm, db)
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +69,7 @@ func TestCheckAllDatabases(t *testing.T) {
 	rm, mock := maintenanceTestRM(t)
 	defer mock.Close()
 
-	states, err := CheckAllDatabases(rm)
+	states, err := CheckAllDatabasesContext(context.Background(), rm)
 	if err != nil {
 		panic(err)
 	}

--- a/rm/repositories_test.go
+++ b/rm/repositories_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,7 +39,7 @@ func TestGetRepositories(t *testing.T) {
 	rm, mock := repositoriesTestRM(t)
 	defer mock.Close()
 
-	repos, err := GetRepositories(rm)
+	repos, err := GetRepositoriesContext(context.Background(), rm)
 	if err != nil {
 		t.Error(err)
 	}
@@ -57,7 +58,7 @@ func TestGetRepositoryByName(t *testing.T) {
 
 	dummyRepoIdx := 0
 
-	repo, err := GetRepositoryByName(rm, dummyRepos[dummyRepoIdx].Name)
+	repo, err := GetRepositoryByNameContext(context.Background(), rm, dummyRepos[dummyRepoIdx].Name)
 	if err != nil {
 		t.Error(err)
 	}

--- a/rm/roles.go
+++ b/rm/roles.go
@@ -2,6 +2,7 @@ package nexusrm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -17,13 +18,13 @@ type Role struct {
 	Roles       []string `json:"roles"`
 }
 
-func CreateRole(rm RM, role Role) error {
+func CreateRoleContext(ctx context.Context, rm RM, role Role) error {
 	json, err := json.Marshal(role)
 	if err != nil {
 		return err
 	}
 
-	_, resp, err := rm.Post(restRole, bytes.NewBuffer(json))
+	_, resp, err := rm.Post(ctx, restRole, bytes.NewBuffer(json))
 	if err != nil && resp.StatusCode != http.StatusNoContent {
 		return err
 	}
@@ -31,12 +32,20 @@ func CreateRole(rm RM, role Role) error {
 	return nil
 }
 
-func DeleteRoleById(rm RM, id string) error {
+func CreateRole(rm RM, role Role) error {
+	return CreateRoleContext(context.Background(), rm, role)
+}
+
+func DeleteRoleByIdContext(ctx context.Context, rm RM, id string) error {
 	url := fmt.Sprintf("%s/%s", restRole, id)
 
-	if resp, err := rm.Del(url); err != nil && resp.StatusCode != http.StatusNoContent {
+	if resp, err := rm.Del(ctx, url); err != nil && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("role not deleted '%s': %v", id, err)
 	}
 
 	return nil
+}
+
+func DeleteRoleById(rm RM, id string) error {
+	return DeleteRoleByIdContext(context.Background(), rm, id)
 }

--- a/rm/scripts_test.go
+++ b/rm/scripts_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -128,7 +129,7 @@ func TestScriptList(t *testing.T) {
 	rm, mock := scriptsTestRM(t)
 	defer mock.Close()
 
-	scripts, err := ScriptList(rm)
+	scripts, err := ScriptListContext(context.Background(), rm)
 	if err != nil {
 		t.Error(err)
 	}
@@ -151,7 +152,7 @@ func TestScriptGet(t *testing.T) {
 
 	dummyScriptsIdx := 1
 
-	script, err := ScriptGet(rm, dummyScripts[dummyScriptsIdx].Name)
+	script, err := ScriptGetContext(context.Background(), rm, dummyScripts[dummyScriptsIdx].Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -168,11 +169,11 @@ func TestScriptUpload(t *testing.T) {
 
 	newScript := Script{Name: "newScript", Content: "log.info('I am new!')", Type: "groovy"}
 
-	if err := ScriptUpload(rm, newScript); err != nil {
+	if err := ScriptUploadContext(context.Background(), rm, newScript); err != nil {
 		t.Error(err)
 	}
 
-	script, err := ScriptGet(rm, newScript.Name)
+	script, err := ScriptGetContext(context.Background(), rm, newScript.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -197,11 +198,11 @@ func TestScriptUpdate(t *testing.T) {
 		t.Fatal("I am an idiot")
 	}
 
-	if err := ScriptUpdate(rm, updatedScript); err != nil {
+	if err := ScriptUpdateContext(context.Background(), rm, updatedScript); err != nil {
 		t.Error(err)
 	}
 
-	script, err := ScriptGet(rm, updatedScript.Name)
+	script, err := ScriptGetContext(context.Background(), rm, updatedScript.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -218,15 +219,15 @@ func TestScriptDelete(t *testing.T) {
 
 	deleteMe := Script{Name: "deleteMe", Content: "log.info('Existence is pain!')", Type: "groovy"}
 
-	if err := ScriptUpload(rm, deleteMe); err != nil {
+	if err := ScriptUploadContext(context.Background(), rm, deleteMe); err != nil {
 		t.Error(err)
 	}
 
-	if err := ScriptDelete(rm, deleteMe.Name); err != nil {
+	if err := ScriptDeleteContext(context.Background(), rm, deleteMe.Name); err != nil {
 		t.Error(err)
 	}
 
-	if _, err := ScriptGet(rm, deleteMe.Name); err == nil {
+	if _, err := ScriptGetContext(context.Background(), rm, deleteMe.Name); err == nil {
 		t.Error("Found script which should have been deleted")
 	}
 }
@@ -238,11 +239,11 @@ func TestScriptRun(t *testing.T) {
 	script := Script{Name: "scriptArgsTest", Content: "return args", Type: "groovy"}
 	input := "this is a test"
 
-	if err := ScriptUpload(rm, script); err != nil {
+	if err := ScriptUploadContext(context.Background(), rm, script); err != nil {
 		t.Error(err)
 	}
 
-	ret, err := ScriptRun(rm, script.Name, []byte(input))
+	ret, err := ScriptRunContext(context.Background(), rm, script.Name, []byte(input))
 	if err != nil {
 		t.Error(err)
 	}
@@ -251,7 +252,7 @@ func TestScriptRun(t *testing.T) {
 		t.Errorf("Did not get expected script output: %s\n", ret)
 	}
 
-	if err = ScriptDelete(rm, script.Name); err != nil {
+	if err = ScriptDeleteContext(context.Background(), rm, script.Name); err != nil {
 		t.Error(err)
 	}
 }
@@ -263,7 +264,7 @@ func TestScriptRunOnce(t *testing.T) {
 	script := Script{Name: "scriptArgsTest", Content: "return args", Type: "groovy"}
 	input := "this is a test"
 
-	ret, err := ScriptRunOnce(rm, script, []byte(input))
+	ret, err := ScriptRunOnceContext(context.Background(), rm, script, []byte(input))
 	if err != nil {
 		t.Error(err)
 	}
@@ -272,7 +273,7 @@ func TestScriptRunOnce(t *testing.T) {
 		t.Errorf("Did not get expected script output: %s\n", ret)
 	}
 
-	if _, err = ScriptGet(rm, script.Name); err == nil {
+	if _, err = ScriptGetContext(context.Background(), rm, script.Name); err == nil {
 		t.Error("Found script which should have been deleted")
 	}
 }

--- a/rm/search_test.go
+++ b/rm/search_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -78,7 +79,7 @@ func TestSearchComponents(t *testing.T) {
 	repo := "repo-maven"
 
 	query := NewSearchQueryBuilder().Repository(repo)
-	components, err := SearchComponents(rm, query)
+	components, err := SearchComponentsContext(context.Background(), rm, query)
 	if err != nil {
 		t.Fatalf("Did not complete search: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestSearchAssets(t *testing.T) {
 	repo := "repo-maven"
 
 	query := NewSearchQueryBuilder().Repository(repo)
-	assets, err := SearchAssets(rm, query)
+	assets, err := SearchAssetsContext(context.Background(), rm, query)
 	if err != nil {
 		t.Error(err)
 	}
@@ -128,7 +129,7 @@ func ExampleSearchComponents() {
 	}
 
 	query := NewSearchQueryBuilder().Repository("maven-releases")
-	components, err := SearchComponents(rm, query)
+	components, err := SearchComponentsContext(context.Background(), rm, query)
 	if err != nil {
 		panic(err)
 	}

--- a/rm/staging.go
+++ b/rm/staging.go
@@ -1,6 +1,9 @@
 package nexusrm
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // service/rest/v1/staging/move/{repository}
 const (
@@ -38,19 +41,27 @@ type componentsDeleted struct {
 	Version    string `json:"version"`
 }
 
-// StagingMove promotes components which match a set of criteria
-func StagingMove(rm RM, query QueryBuilder) error {
+func StagingMoveContext(ctx context.Context, rm RM, query QueryBuilder) error {
 	endpoint := fmt.Sprintf("%s?%s", restStaging, query.Build())
 
 	// TODO: handle response
-	_, _, err := rm.Post(endpoint, nil)
+	_, _, err := rm.Post(ctx, endpoint, nil)
+	return err
+}
+
+// StagingMove promotes components which match a set of criteria
+func StagingMove(rm RM, query QueryBuilder) error {
+	return StagingMoveContext(context.Background(), rm, query)
+}
+
+func StagingDeleteContext(ctx context.Context, rm RM, query QueryBuilder) error {
+	endpoint := fmt.Sprintf("%s?%s", restStaging, query.Build())
+
+	_, err := rm.Del(ctx, endpoint)
 	return err
 }
 
 // StagingDelete removes components which have been staged
 func StagingDelete(rm RM, query QueryBuilder) error {
-	endpoint := fmt.Sprintf("%s?%s", restStaging, query.Build())
-
-	_, err := rm.Del(endpoint)
-	return err
+	return StagingDeleteContext(context.Background(), rm, query)
 }

--- a/rm/status.go
+++ b/rm/status.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -9,14 +10,22 @@ const (
 	restStatusWritable = "service/rest/v1/status/writable"
 )
 
+func StatusReadableContext(ctx context.Context, rm RM) (_ bool) {
+	_, resp, err := rm.Get(ctx, restStatusReadable)
+	return err == nil && resp.StatusCode == http.StatusOK
+}
+
 // StatusReadable returns true if the RM instance can serve read requests
 func StatusReadable(rm RM) (_ bool) {
-	_, resp, err := rm.Get(restStatusReadable)
+	return StatusReadableContext(context.Background(), rm)
+}
+
+func StatusWritableContext(ctx context.Context, rm RM) (_ bool) {
+	_, resp, err := rm.Get(ctx, restStatusWritable)
 	return err == nil && resp.StatusCode == http.StatusOK
 }
 
 // StatusWritable returns true if the RM instance can serve read requests
 func StatusWritable(rm RM) (_ bool) {
-	_, resp, err := rm.Get(restStatusWritable)
-	return err == nil && resp.StatusCode == http.StatusOK
+	return StatusWritableContext(context.Background(), rm)
 }

--- a/rm/support.go
+++ b/rm/support.go
@@ -2,6 +2,7 @@ package nexusrm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"mime"
@@ -41,14 +42,13 @@ func NewSupportZipOptions() (o SupportZipOptions) {
 	return
 }
 
-// GetSupportZip generates a support zip with the given options
-func GetSupportZip(rm RM, options SupportZipOptions) ([]byte, string, error) {
+func GetSupportZipContext(ctx context.Context, rm RM, options SupportZipOptions) ([]byte, string, error) {
 	request, err := json.Marshal(options)
 	if err != nil {
 		return nil, "", fmt.Errorf("error retrieving support zip: %v", err)
 	}
 
-	body, resp, err := rm.Post(restSupportZip, bytes.NewBuffer(request))
+	body, resp, err := rm.Post(ctx, restSupportZip, bytes.NewBuffer(request))
 	if err != nil {
 		return nil, "", fmt.Errorf("error retrieving support zip: %v", err)
 	}
@@ -62,4 +62,9 @@ func GetSupportZip(rm RM, options SupportZipOptions) ([]byte, string, error) {
 	}
 
 	return body, params["filename"], nil
+}
+
+// GetSupportZip generates a support zip with the given options
+func GetSupportZip(rm RM, options SupportZipOptions) ([]byte, string, error) {
+	return GetSupportZipContext(context.Background(), rm, options)
 }

--- a/rm/tagging_test.go
+++ b/rm/tagging_test.go
@@ -1,6 +1,7 @@
 package nexusrm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -99,7 +100,7 @@ func TestTagsList(t *testing.T) {
 	rm, mock := taggingTestRM(t)
 	defer mock.Close()
 
-	tags, err := TagsList(rm)
+	tags, err := TagsListContext(context.Background(), rm)
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,7 +122,7 @@ func TestGetTag(t *testing.T) {
 
 	want := dummyTags[0]
 
-	got, err := GetTag(rm, want.Name)
+	got, err := GetTagContext(context.Background(), rm, want.Name)
 	if err != nil {
 		t.Error(err)
 	}
@@ -139,7 +140,7 @@ func TestAddTag(t *testing.T) {
 
 	newName := "newTestTag"
 
-	got, err := AddTag(rm, newName, nil)
+	got, err := AddTagContext(context.Background(), rm, newName, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -148,7 +149,7 @@ func TestAddTag(t *testing.T) {
 		t.Error("Did not get tag with expected name")
 	}
 
-	gotAgain, err := GetTag(rm, newName)
+	gotAgain, err := GetTagContext(context.Background(), rm, newName)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Almost all public functions of this library make one or more HTTP requests behind the scenes.
Since this is an operation that can potentially block indefinitely, it is good practice to pass a context into these functions. That way, the operation can be cancelled "from above" if necessary.

Add ...Context() variants of all public functions that end up making HTTP requests. Maintain external API compatibility by keeping the old functions as wrappers, calling the new ...Context() functions with context.Background().

An exception to this is the Client interface in nexus.go and its implementation. There, the context parameter is added directly. This is technically a breaking change, but I suspect not many people will be using this low-level interface anyway.